### PR TITLE
Fix #9: add Ghostscript for EPS import

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -237,11 +237,24 @@
                 "--disable-cups",
                 "--disable-openjpeg",
                 "--disable-gtk",
-                "--disable-sse2",
                 "--without-libtiff",
                 "--without-libjbig2dec",
                 "--with-drivers=PS"
             ],
+            "build-options": {
+                "arch": {
+                    "arm": {
+                        "config-opts": [
+                            "--disable-sse2"
+                        ]
+                    },
+                    "aarch64": {
+                        "config-opts": [
+                            "--disable-sse2"
+                        ]
+                    }
+                }
+            },
             "sources": [
                 {
                     "type": "archive",

--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -28,6 +28,7 @@
         "/share/doc",
         "/share/gc",
         "/share/info",
+        "/share/man",
         "/share/pkgconfig",
         "*.la",
         "*.a"
@@ -225,6 +226,27 @@
                     "type": "archive",
                     "url": "https://poppler.freedesktop.org/poppler-0.55.0.tar.xz",
                     "sha256": "537f2bc60d796525705ad9ca8e46899dcc99c2e9480b80051808bae265cdc658"
+                }
+            ]
+        },
+        {
+            "name": "ghostscript",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-dbus",
+                "--disable-cups",
+                "--disable-openjpeg",
+                "--disable-gtk",
+                "--disable-sse2",
+                "--without-libtiff",
+                "--without-libjbig2dec",
+                "--with-drivers=PS"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-9.23.tar.gz",
+                    "sha256": "f65964807a3c97a2c0810d4b9806585367e73129e57ae33378cea18e07a1ed9b"
                 }
             ]
         },


### PR DESCRIPTION
This addresses #9 and works on my machine. ~However, I deliberately disabled SSE2 support because I suppose it would cause problems on ARM architectures (@TingPing ?).~ Moreover, for such a small feature it's quite an increase in terms of size because the `gs` binary adds about 15 MB, I don't know how much more this could be stripped with compiler flags …