### PR TITLE
Beta: upgrade to 1.0

### DIFF
--- a/inkscape-appdata.patch
+++ b/inkscape-appdata.patch
@@ -1,0 +1,16 @@
+diff --git a/org.inkscape.Inkscape.appdata.xml.in b/org.inkscape.Inkscape.appdata.xml.in
+index cfd422d807..38e3d706f2 100644
+--- a/org.inkscape.Inkscape.appdata.xml.in
++++ b/org.inkscape.Inkscape.appdata.xml.in
+@@ -72,9 +72,9 @@
+         <ul>
+           <li>Bugfix release</li>
+           <li>More python3 compatibility for extensions</li>
+-	</ul>
+-	  <url>https://wiki.inkscape.org/wiki/index.php/Release_notes/0.92.5</url>
++        </ul>
+       </description>
++      <url>https://wiki.inkscape.org/wiki/index.php/Release_notes/0.92.5</url>
+     </release>
+     <release version="0.92.4" date="2019-01-16">
+       <description>

--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -439,7 +439,7 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://inkscape.org/gallery/item/18460/inkscape-1.0_2020-05-01_4035a4fb49.tar.xz",
+                    "url": "https://inkscape.org/gallery/item/18460/inkscape-1.0.tar.xz",
                     "sha256": "89c123d1a62ac52db6a08fe3be730584411b89a88ecc528a410b4f3fa53f94bb"
                 },
                 {

--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -439,8 +439,12 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://inkscape.org/gallery/item/18046/inkscape-1.0rc1_2020-04-09_09960d6f05.tar.xz",
-                    "sha256": "e0ddad9c7281744318f4ff02f98c62b400a6a96dad17885bd211dec1ca732432"
+                    "url": "https://inkscape.org/gallery/item/18460/inkscape-1.0_2020-05-01_4035a4fb49.tar.xz",
+                    "sha256": "89c123d1a62ac52db6a08fe3be730584411b89a88ecc528a410b4f3fa53f94bb"
+                },
+                {
+                    "type": "patch",
+                    "path": "inkscape-appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
- Closes #36
- Closes #22
- Closes #3


(this is also part of #53 for `stable`, but to keep the beta branch at least up to date.