### PR TITLE
Bump dependencies to their latest version

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -27,7 +27,7 @@
     ],
     "modules": [
         {
-            "name": "boost",
+            "name": "boost-headers",
             "buildsystem": "simple",
             "build-commands": [
                 "mkdir -p /app/include",

--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -214,7 +214,7 @@
         "python3-scour.json",
         {
             "name": "poppler-data",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "archive",
@@ -225,7 +225,7 @@
         },
         {
             "name": "poppler",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DENABLE_LIBOPENJPEG=none",
                 "-DENABLE_UNSTABLE_API_ABI_HEADERS=ON"

--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -225,10 +225,10 @@
         },
         {
             "name": "poppler",
-            "buildsystem": "autotools",
+            "buildsystem": "cmake",
             "config-opts": [
-                "--enable-libopenjpeg=none",
-                "--enable-xpdf-headers"
+                "-DENABLE_LIBOPENJPEG=none",
+                "-DENABLE_UNSTABLE_API_ABI_HEADERS=ON"
             ],
             "sources": [
                 {

--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2",
-                    "sha256": "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
+                    "url": "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2",
+                    "sha256": "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402"
                 }
             ]
         },
@@ -46,8 +46,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/mm-common/0.9/mm-common-0.9.12.tar.xz",
-                    "sha256": "ceffdcce1e5b52742884c233ec604bf6fded12eea9da077ce7a62c02c87e7c0b"
+                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.0.tar.xz",
+                    "sha256": "b97d9b041e5952486cab620b44ab09f6013a478f43b6699ae899b8a4da189cd4"
                 }
             ],
             "cleanup": [
@@ -62,24 +62,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.1.tar.xz",
-                    "sha256": "c9a25f26178c6cbb147f9904d8c533b5a5c5111a41ac2eb781eb734eea446003"
-                }
-            ]
-        },
-        {
-            "name": "sigc++-3",
-            "config-opts": [
-                "--disable-documentation"
-            ],
-            "cleanup": [
-                "/lib/sigc++-3.0"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc++/2.99/libsigc++-2.99.12.tar.xz",
-                    "sha256": "d902ae277f5baf2d56025586e2153cc2f158472e382723c67f49049f7c6690a8"
+                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.3.tar.xz",
+                    "sha256": "0b68dfc6313c6cc90ac989c6d722a1bf0585ad13846e79746aa87cb265904786"
                 }
             ]
         },
@@ -88,8 +72,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnu.org/gnu/gsl/gsl-2.5.tar.gz",
-                    "sha256": "0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d"
+                    "url": "https://ftp.gnu.org/gnu/gsl/gsl-2.6.tar.gz",
+                    "sha256": "b782339fc7a38fe17689cb39966c4d821236c28018b6593ddb6fd59ee40786a8"
                 }
             ]
         },
@@ -98,8 +82,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/ivmai/bdwgc/archive/v8.0.2.tar.gz",
-                    "sha256": "711ef890f7bc473c0b043c6372c09b8b747ac5141c01a32182ccc393f3b272b3"
+                    "url": "https://github.com/ivmai/bdwgc/archive/v8.0.4.tar.gz",
+                    "sha256": "661d6ed06090982520f92cb88e64bb99ba88f18b33734cc2794b5c7de086d8c1"
                 }
             ],
             "modules": [
@@ -112,8 +96,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.8/libatomic_ops-7.6.8.tar.gz",
-                            "sha256": "1d6a279edf81767e74d2ad2c9fce09459bc65f12c6525a40b0cb3e53c089f665"
+                            "url": "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.10/libatomic_ops-7.6.10.tar.gz",
+                            "sha256": "587edf60817f56daf1e1ab38a4b3c729b8e846ff67b4f62a6157183708f099af"
                         }
                     ]
                 }
@@ -143,8 +127,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.58/glibmm-2.58.0.tar.xz",
-                    "sha256": "d34189237b99e88228e6f557f7d6e62f767fe356f395a244f5ad0e486254b645"
+                    "url": "https://download.gnome.org/sources/glibmm/2.64/glibmm-2.64.2.tar.xz",
+                    "sha256": "a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec"
                 }
             ]
         },
@@ -156,8 +140,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/pangomm/2.42/pangomm-2.42.0.tar.xz",
-                    "sha256": "ca6da067ff93a6445780c0b4b226eb84f484ab104b8391fb744a45cbc7edbf56"
+                    "url": "https://download.gnome.org/sources/pangomm/2.42/pangomm-2.42.1.tar.xz",
+                    "sha256": "14bf04939930870d5cfa96860ed953ad2ce07c3fd8713add4a1bfe585589f40f"
                 }
             ]
         },
@@ -188,8 +172,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.0.tar.xz",
-                    "sha256" : "cf5fc92805e581c8303e08d54519457ba07f15b766e9b1edde4862993ac1aa43"
+                    "url" : "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.2.tar.xz",
+                    "sha256" : "6d71091bcd1863133460d4188d04102810e9123de19706fb656b7bb915b4adc3"
                 }
             ]
         },
@@ -234,8 +218,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.7.tar.gz",
-                    "sha256": "e752b0d88a7aba54574152143e7bf76436a7ef51977c55d6bd9a48dccde3a7de"
+                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz",
+                    "sha256": "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012"
                 }
             ]
         },
@@ -249,8 +233,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-0.55.0.tar.xz",
-                    "sha256": "537f2bc60d796525705ad9ca8e46899dcc99c2e9480b80051808bae265cdc658"
+                    "url": "https://poppler.freedesktop.org/poppler-0.88.0.tar.xz",
+                    "sha256": "b4453804e9a5a519e6ceee0ac8f5efc229e3b0bf70419263c239124474d256c7"
                 }
             ]
         },
@@ -266,14 +250,14 @@
             "make-install-args": [ "soinstall" ],
             "cleanup": [
                 "/share/man",
-                "/share/ghostscript/9.26/doc/",
-                "/share/ghostscript/9.26/examples"
+                "/share/ghostscript/9.52/doc/",
+                "/share/ghostscript/9.52/examples"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.xz",
-                    "sha256": "90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598"
+                    "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs952/ghostscript-9.52.tar.xz",
+                    "sha256": "57442acf8b46453a9b5fc6fec738fbbb7e13a3d3e00f1aaaa0975529bc203c7c"
                 },
                 {
                     "type": "shell",
@@ -386,8 +370,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://dev-www.libreoffice.org/src/libcdr/libcdr-0.1.5.tar.xz",
-                    "sha256": "6ace5c499a8be34ad871e825442ce388614ae2d8675c4381756a7319429e3a48"
+                    "url": "https://dev-www.libreoffice.org/src/libcdr/libcdr-0.1.6.tar.xz",
+                    "sha256": "01cd00b04a030977e544433c2d127c997205332cd9b8e35ec0ee17110da7f861"
                 },
                 {
                     "type" : "shell",
@@ -405,8 +389,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/AbiWord/enchant/releases/download/v2.2.3/enchant-2.2.3.tar.gz",
-                            "sha256": "abd8e915675cff54c0d4da5029d95c528362266557c61c7149d53fa069b8076d"
+                            "url": "https://github.com/AbiWord/enchant/releases/download/v2.2.8/enchant-2.2.8.tar.gz",
+                            "sha256": "c7b5e2853f0dd0b1aafea2f9e071941affeec3a76df8e3f6d67a718c89293555"
                         }
                     ]
                 }

--- a/python3-lxml.json
+++ b/python3-lxml.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/16/4a/b085a04d6dad79aa5c00c65c9b2bbcb2c6c22e5ac341e7968e0ad2c57e2f/lxml-4.3.0.tar.gz",
-            "sha256": "d1e111b3ab98613115a208c1017f266478b0ab224a67bc8eac670fa0bad7d488"
+            "url": "https://files.pythonhosted.org/packages/39/2b/0a66d5436f237aff76b91e68b4d8c041d145ad0a2cdeefe2c42f76ba2857/lxml-4.5.0.tar.gz",
+            "sha256": "8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60"
         }
     ]
 }

--- a/python3-numpy.json
+++ b/python3-numpy.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip",
-            "sha256": "3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7"
+            "url": "https://files.pythonhosted.org/packages/2d/f3/795e50e3ea2dc7bc9d1a2eeea9997d5dce63b801e08dfc37c2efce341977/numpy-1.18.4.zip",
+            "sha256": "bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509"
         }
     ]
 }

--- a/python3-numpy.json
+++ b/python3-numpy.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/2d/f3/795e50e3ea2dc7bc9d1a2eeea9997d5dce63b801e08dfc37c2efce341977/numpy-1.18.4.zip",
-            "sha256": "bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509"
+            "url": "https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip",
+            "sha256": "3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7"
         }
     ]
 }

--- a/python3-scour.json
+++ b/python3-scour.json
@@ -12,8 +12,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz",
-            "sha256": "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            "url": "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz",
+            "sha256": "236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"
         }
     ]
 }


### PR DESCRIPTION
I also dropped libsigc++ 3.0 which isn’t used yet.