### PR TITLE
add imagemagick as module

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -409,6 +409,16 @@
                 }
             ]
         },
+	{
+            "name": "imagemagick",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/ImageMagick/ImageMagick/archive/7.0.10-28.tar.gz",
+                    "sha256": "9f2b8b131222354b196c640fca4e53eb0bbf62246621b9d467f223366272d7a7"
+                }
+            ]
+        },
         {
             "name": "inkscape",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
Some extensions need imagemagick, and it can't use from operating system. one of extensions that used imagemagick is [inkporter](https://github.com/raniaamina/inkporter/tree/inkporter-gui)