### PR TITLE
Add x-checker-data for double-conversion, Cython, setuptools, and numpy

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -306,7 +306,12 @@
                     "type": "archive",
                     "url": "https://github.com/google/double-conversion/archive/v3.1.5.tar.gz",
                     "sha256": "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13",
-                    "dest-filename": "double-conversion-3.1.5.tar.gz"
+                    "dest-filename": "double-conversion-3.1.5.tar.gz",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 7454,
+                        "url-template": "https://github.com/google/double-conversion/archive/refs/tags/v${version}.tar.gz"
+                    }
                 }
             ]
         },

--- a/python3-numpy.json
+++ b/python3-numpy.json
@@ -8,7 +8,11 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/18/ad/ec41343a49a0371ea40daf37b1ba2c11333cdd121cb378161635d14b9750/setuptools-59.2.0-py3-none-any.whl",
-            "sha256": "4adde3d1e1c89bde1c643c64d89cdd94cbfd8c75252ee459d4500bccb9c7d05d"
+            "sha256": "4adde3d1e1c89bde1c643c64d89cdd94cbfd8c75252ee459d4500bccb9c7d05d",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "setuptools"
+            }
         },
         {
             "type": "file",
@@ -18,12 +22,20 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/4c/76/1e41fbb365ad20b6efab2e61b0f4751518444c953b390f9b2d36cf97eea0/Cython-0.29.32.tar.gz",
-            "sha256": "8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7"
+            "sha256": "8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "Cython"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/f4/66/17b8e95770478436bf968353c89683ce6f9e14d92e0d4fb3111c09ba18d2/numpy-1.23.2.tar.gz",
-            "sha256": "b78d00e48261fbbd04aa0d7427cf78d18401ee0abd89c7559bbf422e5b1c7d01"
+            "sha256": "b78d00e48261fbbd04aa0d7427cf78d18401ee0abd89c7559bbf422e5b1c7d01",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "numpy"
+            }
         }
     ]
 }


### PR DESCRIPTION
While working on #139, I got flatpak-external-data-checker to check some Python versions. #140 obsoletes my PR, but _if_ it's helpful this adds the `x-checker-data`. Note @hfiguiere comment in #126 "if the bot open PR for no reason, then it's a waste of everything", so feel free to reject.

FWIW, with this change `flatpak run --filesystem=/tmp/org.inkscape.Inkscape org.flathub.flatpak-external-data-checker org.inkscape.Inkscape.json` reports

> OUTDATED: double-conversion-3.1.5.tar.gz
>  Has a new version:
>   Version:   3.2.1
> 
> OUTDATED: setuptools-59.2.0-py3-none-any.whl
>  Has a new version:
>   Version:   67.2.0
> 
> OUTDATED: Cython-0.29.32.tar.gz
>  Has a new version:
>   Version:   0.29.33
> 
> OUTDATED: numpy-1.23.2.tar.gz
>  Has a new version:
>   Version:   1.24.2

in addition to existing outdated tcl8.6.12-src.tar.gz and tk8.6.12-src.tar.gz warnings.

"you are in a maze of twisty little version changes, all alike" -- [Colossal Cave Adventure](https://en.wikiquote.org/wiki/Colossal_Cave_Adventure) :smiley: