### PR TITLE
ghostscript: use dynamic binary by default

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -250,6 +250,9 @@
             ],
             "make-args": [ "so" ],
             "make-install-args": [ "soinstall" ],
+            "post-install": [
+                "mv -f ${FLATPAK_DEST}/bin/{gsc,gs} "
+            ],
             "cleanup": [
                 "/share/man",
                 "/share/ghostscript/9.53/doc/",


### PR DESCRIPTION
ghostscript has two main binaries: one statically linked to libgs (gs) - used by default and one dynamically linked to libgs (gsc). It doesn't make much sense to use statically linked binary when libgs is bundled with the app anyway. This saves ~23MB.

This is what Fedora, Arch and perhaps most distros do:

https://src.fedoraproject.org/rpms/ghostscript/blob/rawhide/f/ghostscript.spec#_298

https://gitlab.archlinux.org/archlinux/packaging/packages/ghostscript/-/blob/main/PKGBUILD?ref_type=heads#L98