### PR TITLE
Change filesystem access from host to xdg-pictures

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -9,7 +9,7 @@
         "--socket=x11",
         "--socket=wayland",
         "--device=dri",
-        "--filesystem=host",
+        "--filesystem=xdg-pictures",
         "--filesystem=xdg-config/gtk-3.0",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",


### PR DESCRIPTION
Remove write access to `host` and replace with write access to `xdg-pictures` . This follows good practice to make the sand-boxing more robust. If `xdg-pictures` is not the right path or an adequate path, we can add an additional one. 

When I try to save or export a project, only the allow-listed filesystem path are shown in the file browser. Same for opening files.

Fixes #155 