### PR TITLE
Remove mm-common

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -53,24 +53,8 @@
             ]
         },
         {
-            "name": "mm-common",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.3.tar.xz",
-                    "sha256": "e81596625899aacf1d0bf27ccc2fcc7f373405ec48735ca1c7273c0fbcdc1ef5"
-                }
-            ],
-            "cleanup": [
-                "*"
-            ]
-        },
-        {
             "name": "sigc++-2",
-            "config-opts": [
-                "--disable-documentation"
-            ],
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
@@ -117,9 +101,7 @@
         },
         {
             "name": "cairomm",
-            "config-opts": [
-                "--disable-documentation"
-            ],
+            "buildsystem": "meson",
             "cleanup": [
                 "/lib/cairomm-1.0"
             ],


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80