### PR TITLE
Make gtk-config dir as read-only

### DIFF
--- a/org.inkscape.Inkscape.json
+++ b/org.inkscape.Inkscape.json
@@ -10,7 +10,7 @@
         "--socket=wayland",
         "--device=dri",
         "--filesystem=host",
-        "--filesystem=xdg-config/gtk-3.0",
+        "--filesystem=xdg-config/gtk-3.0:ro",
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",


### PR DESCRIPTION
Write access shouldn't be needed there, see https://github.com/flathub/org.gtk.Gtk3theme.Breeze#workarounds